### PR TITLE
Refactored logging by shifting common time update condition checks

### DIFF
--- a/Wreck/Corrector/Applicator.cs
+++ b/Wreck/Corrector/Applicator.cs
@@ -9,57 +9,25 @@ namespace Wreck.Corrector
 	/// </summary>
 	public class Applicator : ICorrector
 	{
-		public bool ByCreationMetadata(FileSystemInfo fsi, DateTime? creation) 
+		public void ByCreationMetadata(FileSystemInfo fsi, DateTime? creation)
 		{
-			bool done = false;
-
-			if (creation != null && fsi.CreationTime.CompareTo(creation) > 0) {
-				fsi.CreationTime = (DateTime) creation;
-				done = true;
-			}
-
-			return done;
+			fsi.CreationTime = (DateTime) creation;
 		}
 
-		public bool ByLastWriteMetadata(FileSystemInfo fsi, DateTime? lastWrite)
+		public void ByLastWriteMetadata(FileSystemInfo fsi, DateTime? lastWrite)
 		{
-			bool done = false;
-
-			if (lastWrite != null && fsi.LastWriteTime.CompareTo(lastWrite) > 0) {
-				fsi.LastWriteTime = (DateTime) lastWrite;
-				done = true;
-			}
-
-			return done;
+			fsi.LastWriteTime = (DateTime) lastWrite;
 		}
 
-		public bool ByLastAccessMetadata(FileSystemInfo fsi, DateTime? lastAccess)
+		public void ByLastAccessMetadata(FileSystemInfo fsi, DateTime? lastAccess)
 		{
-			bool done = false;
-
-			if (lastAccess != null && fsi.LastAccessTime.CompareTo(lastAccess) > 0) {
-				fsi.LastAccessTime = (DateTime) lastAccess;
-				done = true;
-			}
-
-			return done;
+			fsi.LastAccessTime = (DateTime) lastAccess;
 		}
 
-		public bool ByLastWriteTime(FileSystemInfo fsi)
+		public void ByLastWriteTime(FileSystemInfo fsi)
 		{
-			bool done = false;
-
-			if (fsi.CreationTime.CompareTo(fsi.LastWriteTime) > 0) {
-				fsi.CreationTime = fsi.LastWriteTime;
-				done = true;
-			}
-
-			if (fsi.LastAccessTime.CompareTo(fsi.LastWriteTime) > 0) {
-				fsi.LastAccessTime = fsi.LastWriteTime;
-				done = true;
-			}
-
-			return done;
+			fsi.CreationTime = fsi.LastWriteTime;
+			fsi.LastAccessTime = fsi.LastWriteTime;
 		}
 	}
 }

--- a/Wreck/Corrector/ICorrector.cs
+++ b/Wreck/Corrector/ICorrector.cs
@@ -6,9 +6,9 @@ namespace Wreck.Corrector
 {
 	public interface ICorrector
 	{
-		bool ByCreationMetadata(FileSystemInfo fsi, DateTime? creation);
-		bool ByLastWriteMetadata(FileSystemInfo fsi, DateTime? lastWrite);
-		bool ByLastAccessMetadata(FileSystemInfo fsi, DateTime? lastAccess);
-		bool ByLastWriteTime(FileSystemInfo fsi);
+		void ByCreationMetadata(FileSystemInfo fsi, DateTime? creation);
+		void ByLastWriteMetadata(FileSystemInfo fsi, DateTime? lastWrite);
+		void ByLastAccessMetadata(FileSystemInfo fsi, DateTime? lastAccess);
+		void ByLastWriteTime(FileSystemInfo fsi);
 	}
 }

--- a/Wreck/Corrector/Previewer.cs
+++ b/Wreck/Corrector/Previewer.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.IO;
+using System.Diagnostics;
 
 namespace Wreck.Corrector
 {
@@ -9,52 +10,24 @@ namespace Wreck.Corrector
 	/// </summary>
 	public class Previewer : ICorrector
 	{
-		public bool ByCreationMetadata(FileSystemInfo fsi, DateTime? creation)
+		public void ByCreationMetadata(FileSystemInfo fsi, DateTime? creation)
 		{
-			bool done = false;
-
-			if (creation != null && fsi.CreationTime.CompareTo(creation) > 0) {
-				done = true;
-			}
-
-			return done;
+			Debug.Print("MC: {0}", fsi.Name);
 		}
 
-		public bool ByLastWriteMetadata(FileSystemInfo fsi, DateTime? lastWrite)
+		public void ByLastWriteMetadata(FileSystemInfo fsi, DateTime? lastWrite)
 		{
-			bool done = false;
-
-			if (lastWrite != null && fsi.LastWriteTime.CompareTo(lastWrite) > 0) {
-				done = true;
-			}
-
-			return done;
+			Debug.Print("MW: {0}", fsi.Name);
 		}
 
-		public bool ByLastAccessMetadata(FileSystemInfo fsi, DateTime? lastAccess)
+		public void ByLastAccessMetadata(FileSystemInfo fsi, DateTime? lastAccess)
 		{
-			bool done = false;
-
-			if (lastAccess != null && fsi.LastAccessTime.CompareTo(lastAccess) > 0) {
-				done = true;
-			}
-
-			return done;
+			Debug.Print("MA: {0}", fsi.Name);
 		}
 
-		public bool ByLastWriteTime(FileSystemInfo fsi)
+		public void ByLastWriteTime(FileSystemInfo fsi)
 		{
-			bool done = false;
-
-			if (fsi.CreationTime.CompareTo(fsi.LastWriteTime) > 0) {
-				done = true;
-			}
-
-			if (fsi.LastAccessTime.CompareTo(fsi.LastWriteTime) > 0) {
-				done = true;
-			}
-
-			return done;
+			Debug.Print("LW: {0}", fsi.Name);
 		}
 	}
 }

--- a/Wreck/Wreck.cs
+++ b/Wreck/Wreck.cs
@@ -154,8 +154,11 @@ namespace Wreck
 			// Fix modification time.
 			try
 			{
-				if(corrector.ByLastWriteMetadata(fsi, lastWrite))
+				if (lastWrite != null && fsi.LastWriteTime.CompareTo(lastWrite) > 0)
+				{
+					corrector.ByLastWriteMetadata(fsi, lastWrite);
 					logger.CorrectedByLastWriteMetadata(fsi, (DateTime) lastWrite);
+				}					
 			}
 			catch(UnauthorizedAccessException ex)
 			{
@@ -166,8 +169,11 @@ namespace Wreck
 			// Fix creation time using specified time,
 			try
 			{
-				if(corrector.ByCreationMetadata(fsi, creation))
+				if (creation != null && fsi.CreationTime.CompareTo(creation) > 0)
+				{
+					corrector.ByCreationMetadata(fsi, creation);
 					logger.CorrectedByCreationMetadata(fsi, (DateTime) creation);
+				}
 			}
 			catch(UnauthorizedAccessException ex)
 			{
@@ -177,8 +183,11 @@ namespace Wreck
 			// Fix access time using specified time, or from modified time.
 			try
 			{
-				if(corrector.ByLastAccessMetadata(fsi, lastAccess))
+				if (lastAccess != null && fsi.LastAccessTime.CompareTo(lastAccess) > 0)
+				{
+					corrector.ByLastAccessMetadata(fsi, lastAccess);
 					logger.CorrectedByLastAccessMetadata(fsi, (DateTime) lastAccess);
+				}
 			}
 			catch(UnauthorizedAccessException ex)
 			{
@@ -190,8 +199,12 @@ namespace Wreck
 			// Last access time will always be earlier than modification time.
 			try
 			{
-				if(corrector.ByLastWriteTime(fsi))
+				if (fsi.CreationTime.CompareTo(fsi.LastWriteTime) > 0 ||
+				   fsi.LastAccessTime.CompareTo(fsi.LastWriteTime) > 0)
+				{
+					corrector.ByLastWriteTime(fsi);
 					logger.CorrectedByLastWriteTime(fsi);
+				}
 			}
 			catch(UnauthorizedAccessException ex)
 			{

--- a/WreckCli/Logging/Logger.cs
+++ b/WreckCli/Logging/Logger.cs
@@ -68,11 +68,8 @@ namespace Wreck.Logging
 		
 		public void CorrectedByLastWriteTime(FileSystemInfo fsi)
 		{
-			if(fsi.CreationTime.CompareTo(fsi.LastWriteTime) > 0)
-				Console.WriteLine("        LC: {0}", FormatTimeSpan(fsi.CreationTime.Subtract(fsi.LastWriteTime)));
-			
-			if(fsi.LastAccessTime.CompareTo(fsi.LastWriteTime) > 0)
-				Console.WriteLine("        LA: {0}", FormatTimeSpan(fsi.LastAccessTime.Subtract(fsi.LastWriteTime)));
+			Console.WriteLine("        LC: {0}", FormatTimeSpan(fsi.CreationTime.Subtract(fsi.LastWriteTime)));
+			Console.WriteLine("        LA: {0}", FormatTimeSpan(fsi.LastAccessTime.Subtract(fsi.LastWriteTime)));
 		}
 		
 		private string FormatTimeSpan(TimeSpan ts)

--- a/WreckGui/Logging/Logger.cs
+++ b/WreckGui/Logging/Logger.cs
@@ -99,11 +99,8 @@ namespace Wreck.Logging
 		
 		public void CorrectedByLastWriteTime(FileSystemInfo fsi)
 		{
-			if(fsi.CreationTime.CompareTo(fsi.LastWriteTime) > 0)
-				Debug.Print("AM: {0} : {1} -> {2}", fsi.Name, fsi.CreationTime, fsi.LastWriteTime);
-			
-			if(fsi.LastAccessTime.CompareTo(fsi.LastWriteTime) > 0)
-				Debug.Print("AM: {0} : {1} -> {2}", fsi.Name, fsi.LastAccessTime, fsi.LastWriteTime);
+			Debug.Print("AM: {0} : {1} -> {2}", fsi.Name, fsi.CreationTime, fsi.LastWriteTime);
+			Debug.Print("AM: {0} : {1} -> {2}", fsi.Name, fsi.LastAccessTime, fsi.LastWriteTime);
 		}
 		
 		public void Statistics(Statistics stats)


### PR DESCRIPTION
For achieving consistent behaviour with timestamp update checks done in single place Wreck class.