### PR TITLE
Test out GitHub Actions fix

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,4 +1,5 @@
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
   pull_request:
@@ -11,24 +12,22 @@ jobs:
         configuration: [Release]
     runs-on: windows-2019
     env:
-      Base_Directory: D:\a\wreck-net\wreck-net
       Solution_Name: Wreck.sln
       Configuration: Release
-      Wap_Project_Directory: bin
       
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+      #- name: Setup .NET
+      #  uses: actions/setup-dotnet@v3
       
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
       
       - name: Build solution
         # run: msbuild $env:Base_Directory\$env:Solution_Name -t:rebuild -property:Configuration=$env:Configuration
-        run: msbuild Wreck.sln /t:Rebuild /p:Configuration=Release
+        run: msbuild Wreck.sln -t:Rebuild -p:Configuration=Release -p:Platform=x86 -p:TargetFrameworkVersion=v2.0
         #run: pwd && ls
         env:
           Configuration: ${{ matrix.configuration }}


### PR DESCRIPTION
1. Disable .NET Core install (to avoid overriding the built-in .NET Framework 4.7.2 on Windows 2019)
2. Update MSBuild command line (add platform and target framework version switches)
3. Enable Workflow Dispatch event for manually running build