### PR TITLE
Fix background worker result return and cleanup dispose call when done

### DIFF
--- a/JShim/Javax/Swing/SwingWorker.cs
+++ b/JShim/Javax/Swing/SwingWorker.cs
@@ -126,6 +126,7 @@ namespace Javax.Swing
 		/// <seealso cref="#Get()">Get()</seealso>
 		protected virtual void Done()
 		{
+			SetState(StateValue.Done);
 			log.Debug("Done");
 		}
 		
@@ -159,6 +160,7 @@ namespace Javax.Swing
 			
 			log.DebugFormat("DoWork: {0}", e.ToString());
 			result = this.DoInBackground();
+			e.Result = result;
 		}
 		
 		void ProgressChanged(object sender, ProgressChangedEventArgs e)
@@ -167,7 +169,7 @@ namespace Javax.Swing
 			
 			// Publish would send only 1 chunk
 			V chunk = (V) e.UserState;
-			log.DebugFormat("ProgressChanged: {0}", chunk.ToString());
+//			log.DebugFormat("ProgressChanged: {0}", progress);
 			
 			// Simulate queuing and batching of chunks into a list.
 			List<V> chunks = new List<V>();
@@ -179,7 +181,6 @@ namespace Javax.Swing
 		
 		void RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
 		{
-			state = StateValue.Done;
 			log.DebugFormat("RunWorkerCompleted: {0}", e.ToString());
 			cancelled = e.Cancelled;
 			result = (T) e.Result;
@@ -206,8 +207,8 @@ namespace Javax.Swing
 		protected void FirePropertyChange(string propertyName, object oldValue,
 		                                  object newValue)
 		{
-			log.DebugFormat("FirePropertyChange: {0}, {1}, {2}",
-			                propertyName, oldValue, newValue);
+//			log.DebugFormat("FirePropertyChange: {0}, {1}, {2}",
+//			                propertyName, oldValue, newValue);
 			GetPropertyChangeSupport().FirePropertyChange(
 				propertyName,
 				oldValue, newValue);
@@ -395,7 +396,9 @@ namespace Javax.Swing
 		/// <param name="progress">the progress value to set</param>
 		protected void SetProgress(int progress)
 		{
+			int old = this.progress;
 			this.progress = progress;
+			FirePropertyChange("progress", old, state);
 		}
 		
 		public enum StateValue

--- a/Wreck/Controller/AbstractController.cs
+++ b/Wreck/Controller/AbstractController.cs
@@ -227,8 +227,6 @@ namespace Wreck.Controller
 				else
 					LOG.ErrorFormat("Unknown path type: {0}", d);
 			}
-			
-			Done();
 		}
 		
 		public virtual void Run(CorrectionMode mode, FileSystemInfo fsi)

--- a/WreckGui/Controller/GuiController.cs
+++ b/WreckGui/Controller/GuiController.cs
@@ -88,10 +88,12 @@ namespace Wreck.Controller
 			GuiWorker pw = new GuiWorker(task, fsi);
 			pw.AddPropertyChangeListener(propertyChangeListener);
 			pw.Execute();
+			Worker = pw; // Need to save to Worker for cleanup later.
 		}
 		
 		private class ProgressPropertyChangeListener : PropertyChangeListener
 		{
+			private static readonly ILog LOG = LogManager.GetLogger(typeof(GuiController.ProgressPropertyChangeListener));
 			GuiController controller;
 			public ProgressPropertyChangeListener(GuiController controller)
 			{
@@ -112,18 +114,25 @@ namespace Wreck.Controller
 				else if (R.strings.PROPERTY_PROGRESS.Equals(evt.PropertyName))
 				{
 					int progress = (int)evt.NewValue;
+					LOG.InfoFormat("Progress: {0}%", progress);
 //					Model.GetScanningProgressModel().SetValue(progress);
 				}
 				else if (R.strings.PROPERTY_VISITS.Equals(evt.PropertyName))
 				{
 					FileVisit visit = (FileVisit) evt.NewValue;
-					
+					LOG.InfoFormat("Progress: {0}% - Visit: {0}", visit.Progress, visit.File.FullName);
 //					View.GetScanningDialog().SetProgress(visit.GetProgress());
 //					View.GetScanningDialog().GetAction().SetText(visit.GetFile().GetFileName().ToString());
 				}
 				else if(R.strings.PROPERTY_BEAN.Equals(evt.PropertyName))
 				{
 					FileBean update = (FileBean) evt.NewValue;
+					LOG.InfoFormat("FileBean: {0} {1} {2} {3} {4}",
+					               update.Path.Name,
+					               update.Creation.ToString(),
+					               update.Modified.ToString(),
+					               update.Metadata.ToString(),
+					               update.Period.ToString());
 //					Model.GetTableModel().AddRow(update);
 				}
 			}

--- a/WreckGui/IO/GuiWorker.cs
+++ b/WreckGui/IO/GuiWorker.cs
@@ -104,6 +104,7 @@ namespace Wreck.IO
 			{
 				string result = Get();
 				LOG.DebugFormat("Done: {0}", result);
+				base.Done();
 			}
 			catch (Exception e)
 			{

--- a/WreckGui/WreckGui.csproj
+++ b/WreckGui/WreckGui.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>WreckGui</AssemblyName>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <SourceAnalysisOverrideSettingsFile>C:\Users\USER\AppData\Roaming\ICSharpCode/SharpDevelop3.0\Settings.SourceAnalysis</SourceAnalysisOverrideSettingsFile>
-    <StartArguments>"C:\temp\Public\Pictures\Sample Pictures\Chrysanthemum.jpg"</StartArguments>
+    <StartArguments>"C:\temp\Public"</StartArguments>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <NoStdLib>False</NoStdLib>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
1. Fix result return from background worker when done
2. Triggers the controller Done() to do cleanup (e.g. shutdown ExifTool) when done
3. Fix Worker reference saving in controller after being created by WreckService