### PR TITLE
Change default max seconds to prevent overflowing to following day

### DIFF
--- a/Wreck/IO/Reader/Fs/PathReader.cs
+++ b/Wreck/IO/Reader/Fs/PathReader.cs
@@ -55,7 +55,7 @@ namespace Wreck.IO.Reader.Fs
 		
 		public const int MAX_HH = 23;
 		public const int MAX_MM = 59;
-		public const int MAX_SS = 59;
+		public const int MAX_SS = 00;
 		
 		public PathReader() : base()
 		{


### PR DESCRIPTION
To prevent automatic rounding up by Windows/File Explorer which overflows to the the following day 12am.

For example, setting a date like 01 Jan 2000 23:59:59 would be rounded up as 02 Jan 2000 00:00 (12am) due to **rounding up to the nearest minute**, instead of rounding down or truncating.

Instead setting to 01 Jan 2000 23:59:00 would be displayed as 01 Jan 2000. So the seconds field would not cause an overflow to preserve the date field.