### PR TITLE
Fix default custom DateTime value bug

### DIFF
--- a/Wreck/IO/Reader/User/CustomDateTimeReader.cs
+++ b/Wreck/IO/Reader/User/CustomDateTimeReader.cs
@@ -24,7 +24,7 @@ namespace Wreck.IO.Reader.User
 		
 		public CustomDateTimeReader() : base()
 		{
-			custom = new DateTime();
+			custom = DateTime.Now;
 		}
 		
 		public override string[] Creation()

--- a/WreckGui/Model/GuiModel.cs
+++ b/WreckGui/Model/GuiModel.cs
@@ -57,7 +57,7 @@ namespace Wreck.Model
 				this.SourceModel.Add(s, true);
 			}
 			
-			this.customDateTimeModel = new DateTime();
+			this.customDateTimeModel = DateTime.Now;
 			
 			this.correctionModel = new Dictionary<CorrectionEnum, Boolean>();
 			foreach(CorrectionEnum c in CorrectionEnum.Values)


### PR DESCRIPTION
Java `new Date()` defaults to **current time of object instantiation**, which would not trip the special cases by default.
C#.NET `new DateTime()` defaults to a hard coded **01-01-0001 00:00:00.000** which causes the extracted metadata value to be overwritten.

This causes confusion in the date time value selection in TimestampReducer that picks the wrong default file system value because the supposed user-defined custom date time is earlier than even the application-defined lower limit of **01-01-1980**.

This is further overwritten by a placeholder value introduced during development which defaults to the current file system file time (creation, last modified, last accessed).

In summary, the bug was a series of wrong values replacing each other:

1. Accurate extracted value replaced by the wrong date time default value of **01-01-0001**
2. 01-01-0001 as a user-defined time is replaced by the application `TimeUtils.VALID_PERIOD_MIN` limit of 01-01-1980 allowed by Windows Explorer
3. The 01-01-1980 value limit is replaced by a placeholder value filled with the current file system time. 

The placeholder value was introduced to allow the application to run but was forgotten.